### PR TITLE
feat: add em terraform example

### DIFF
--- a/examples/terraform/equinix-metal/.terraform.lock.hcl
+++ b/examples/terraform/equinix-metal/.terraform.lock.hcl
@@ -1,0 +1,49 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/equinix/equinix" {
+  version     = "1.11.1"
+  constraints = "1.11.1"
+  hashes = [
+    "h1:byMoA1Tdm4omgcvXCG7F4U3883yMppKFqUIWfRewchY=",
+    "h1:zY9lHFA+SPAZxeElvaNt0/2d/e6GaPVObnwseI8A/m0=",
+    "zh:0441965d03d1b378ab99205e55067cc5fc60b2a22886ee1ef62f910a988cd2d8",
+    "zh:1013a1276f95ee5deefed9ddea97d9018490843151af90558f0f4e656f9a037e",
+    "zh:182ebd08581581e572f680689b08bad7928bf183b7258ded5aab31e0b9dd0138",
+    "zh:58c0c4fe74581855e7240124a5c200d09f2b2834f0640b2a61e6b8c1fd0e778d",
+    "zh:5c8ed70611d980dd34aebcf8f6faecc028535df6e2c6ec2ec40fd918623da7b7",
+    "zh:5d388a2bc4acb25c2e7728c94cc18b0af1e367a716b296e24d58a361d31e6363",
+    "zh:61fe36fc2ba1e78f96bfc09c401d264d96dc6d09df9d58f83120630ee1941de5",
+    "zh:6d0f4705c6ab48e0e983688b9dc171ef9e1e2b9706927701a53a234519f25b36",
+    "zh:70fbfd6e59f644c2d5467085c7ab073a6b6313d95fd90a626e34c126a3078a7c",
+    "zh:823df43ac4e4d38e5b6b4310f3c888b7ffe0f6cd234897a0c76edebef4842f42",
+    "zh:8824ba6ac9689bfd570566796843407df3aa995b18cf4986db9d541701500209",
+    "zh:a5dede4d4c4dae6574e0efaf1f91d310cca8382002b95bf690b4cb336ec26876",
+    "zh:ed8bfd649f636e2fa91fc962c1da1d6a3fc2e5769222664f8a7b382c3dbf85fe",
+    "zh:f54cecbdec8e82e71be3561cf5c68351dbbe2f290826068fa19b5a30735a444a",
+  ]
+}
+
+provider "registry.terraform.io/siderolabs/talos" {
+  version     = "0.1.0"
+  constraints = "0.1.0"
+  hashes = [
+    "h1:QsclpvR/YYCkpo7E5eKNEDHjEejmgq/7dxtG3ty3N7k=",
+    "h1:V2z+f0b6WGFRmCSwjnWmkm5egG6xcl4kPlm5B3ONckM=",
+    "zh:0fa82a384b25a58b65523e0ea4768fa1212b1f5cfc0c9379d31162454fedcc9d",
+    "zh:1d21468270d168195be50f9162d9e21488a6016e54daa0dec8e7341f97ef0664",
+    "zh:1dea41707debf4e323d25eef3924796d76ee2c6d70ff37788cbabc029b4d7ffc",
+    "zh:3e5b78ecc39a32eaa62d3f2d6394730ba1ad3e1283adbc61898caa8cc8e83e01",
+    "zh:5e8e83852c568d0385d64252d021e1df65710f1c9cf566a7ec04b8f782188e68",
+    "zh:61432003375e04f641e3d0a6c833bbf336696e9914bb2f6c80cb509a69208a51",
+    "zh:63354e6ef09c19970157912bba25888d8312aac4a16dd8c3da91da8bfc18a71d",
+    "zh:81e433b4b4a19fa83c3246717a1adb8d827c6515d20b7badb404f3ee5147017a",
+    "zh:9499a566fd1b4c0508320dc369a63b7cdd766471a96e275379959e0ae29dd9c8",
+    "zh:add534d67853b37a95ac78a19941a360a24dc616e3b87bfc3970f221516b40cd",
+    "zh:d3c0b5f092acb4f21c8bf1f9be9dd4302420b34a06d784997f8175b2ecebe61d",
+    "zh:d462db34bd75ea111ff23bfdd3af251486dbf8e21f2d07a410105bd3aeb7e055",
+    "zh:d4661849ea0ba3859f905f7811b331eff0b87e3644fa9a97a6789feaf0333464",
+    "zh:e28b1675ca3d0ccbc68df1410e641b1ca618a2d97ad6fc663d4da6a24c934663",
+    "zh:fcab9b06b397d2a25c86040f3c6ae5dc21764b0bf5adc3796f76cba8d99970b4",
+  ]
+}

--- a/examples/terraform/equinix-metal/README.md
+++ b/examples/terraform/equinix-metal/README.md
@@ -1,0 +1,22 @@
+# Equnix Metal Terraform Example
+
+This example will create an HA Talos cluster on Equinix Metal.
+It will use the built-in Talos offering that is present in Equnix Metal and should result in a stable, maintainable cluster.
+
+## Prereqs
+
+Export the `TF_VAR_em_api_token` environment variable with your API key obtained from Equinix Metal.
+This environment variable will set the token for the Equinix Metal provider to function properly, as well as pass this token to Talos itself so that it can manage the VIP that is created for the cluster.
+You can also enter this API token during the apply below.
+From this directory, issue `terraform init` to ensure the proper providers are pulled down.
+
+## Usage
+
+To create a default cluster, this should be as simple as `terraform apply`.
+This will create a cluster called `talos-em` with 3 control plane nodes and a single worker in the Washington DC region.
+It will also create an elastic IP that is used 
+Each of these machines will their smallest offering, the `c3.small.x86`.
+If different specs or regions are required, override them through command line with the `-var` flag or by creating a varsfile and overriding with `-var-file`.
+Destroying the cluster should, again, be a simple `terraform destroy`.
+
+Getting the kubeconfig and talosconfig for this cluster can be done with `terraform output -raw kubeconfig > <desired-path-and-filename>` and `terraform output -raw talosconfig > <desired-path-and-filename>`.

--- a/examples/terraform/equinix-metal/main.tf
+++ b/examples/terraform/equinix-metal/main.tf
@@ -1,0 +1,85 @@
+# Create EM resources
+
+resource "equinix_metal_reserved_ip_block" "talos_control_plane_vip" {
+  project_id  = var.em_project_id
+  type        = "public_ipv4"
+  metro       = var.em_region
+  quantity    = 1
+  description = "${var.cluster_name} Control Plane VIP"
+}
+
+resource "equinix_metal_device" "talos_control_plane" {
+  project_id       = var.em_project_id
+  plan             = var.em_plan
+  metro            = var.em_region
+  operating_system = "talos_v1"
+  billing_cycle    = "hourly"
+  hostname         = "${var.cluster_name}-control-plane-${count.index}"
+  count            = var.num_control_plane
+}
+
+resource "equinix_metal_device" "talos_worker" {
+  project_id       = var.em_project_id
+  plan             = var.em_plan
+  metro            = var.em_region
+  operating_system = "talos_v1"
+  billing_cycle    = "hourly"
+  hostname         = "${var.cluster_name}-worker-${count.index}"
+  count            = var.num_workers
+}
+
+# Configure and bootstrap Talos
+
+resource "talos_machine_secrets" "machine_secrets" {}
+
+resource "talos_client_configuration" "talosconfig" {
+  cluster_name    = var.cluster_name
+  machine_secrets = talos_machine_secrets.machine_secrets.machine_secrets
+  endpoints       = equinix_metal_device.talos_control_plane[*].access_public_ipv4
+}
+
+resource "talos_machine_configuration_controlplane" "machineconfig_cp" {
+  cluster_name     = var.cluster_name
+  cluster_endpoint = "https://${equinix_metal_reserved_ip_block.talos_control_plane_vip.network}:6443"
+  machine_secrets  = talos_machine_secrets.machine_secrets.machine_secrets
+}
+
+resource "talos_machine_configuration_apply" "cp_config_apply" {
+  talos_config          = talos_client_configuration.talosconfig.talos_config
+  machine_configuration = talos_machine_configuration_controlplane.machineconfig_cp.machine_config
+  count                 = length(equinix_metal_device.talos_control_plane)
+  endpoint              = equinix_metal_device.talos_control_plane[count.index].access_public_ipv4
+  node                  = equinix_metal_device.talos_control_plane[count.index].access_public_ipv4
+  config_patches = [
+    templatefile("${path.module}/templates/vip.yaml.tmpl", {
+      em_vip_ip    = equinix_metal_reserved_ip_block.talos_control_plane_vip.network
+      em_api_token = var.em_api_token
+    })
+  ]
+}
+
+resource "talos_machine_configuration_controlplane" "machineconfig_worker" {
+  cluster_name     = var.cluster_name
+  cluster_endpoint = "https://${equinix_metal_reserved_ip_block.talos_control_plane_vip.network}:6443"
+  machine_secrets  = talos_machine_secrets.machine_secrets.machine_secrets
+}
+
+resource "talos_machine_configuration_apply" "worker_config_apply" {
+  talos_config          = talos_client_configuration.talosconfig.talos_config
+  machine_configuration = talos_machine_configuration_controlplane.machineconfig_worker.machine_config
+  count                 = length(equinix_metal_device.talos_worker)
+  endpoint              = equinix_metal_device.talos_worker[count.index].access_public_ipv4
+  node                  = equinix_metal_device.talos_worker[count.index].access_public_ipv4
+}
+
+resource "talos_machine_bootstrap" "bootstrap" {
+  talos_config = talos_client_configuration.talosconfig.talos_config
+  endpoint     = equinix_metal_device.talos_control_plane[0].access_public_ipv4
+  node         = equinix_metal_device.talos_control_plane[0].access_public_ipv4
+}
+
+resource "talos_cluster_kubeconfig" "kubeconfig" {
+  talos_config = talos_client_configuration.talosconfig.talos_config
+  endpoint     = equinix_metal_device.talos_control_plane[0].access_public_ipv4
+  node         = equinix_metal_device.talos_control_plane[0].access_public_ipv4
+}

--- a/examples/terraform/equinix-metal/outputs.tf
+++ b/examples/terraform/equinix-metal/outputs.tf
@@ -1,0 +1,10 @@
+
+output "talosconfig" {
+  value     = talos_client_configuration.talosconfig.talos_config
+  sensitive = true
+}
+
+output "kubeconfig" {
+  value     = talos_cluster_kubeconfig.kubeconfig.kube_config
+  sensitive = true
+}

--- a/examples/terraform/equinix-metal/templates/vip.yaml.tmpl
+++ b/examples/terraform/equinix-metal/templates/vip.yaml.tmpl
@@ -1,0 +1,8 @@
+machine:
+  network:
+    interfaces:
+      - interface: bond0
+        vip:
+          ip: ${em_vip_ip}
+          equinixMetal:
+            apiToken: ${em_api_token}

--- a/examples/terraform/equinix-metal/variables.tf
+++ b/examples/terraform/equinix-metal/variables.tf
@@ -1,0 +1,40 @@
+variable "em_api_token" {
+  description = "API token for Equinix Metal"
+  type        = string
+  sensitive   = true
+}
+
+variable "cluster_name" {
+  description = "Name of cluster"
+  type        = string
+  default     = "talos-em"
+}
+
+variable "num_control_plane" {
+  description = "Number of control plane nodes to create"
+  type        = number
+  default     = 3
+}
+
+variable "num_workers" {
+  description = "Number of worker nodes to create"
+  type        = number
+  default     = 1
+}
+
+variable "em_region" {
+  description = "Equinix Metal region to use"
+  type        = string
+  default     = "dc"
+}
+
+variable "em_plan" {
+  description = "Equinix Metal server to use"
+  type        = string
+  default     = "c3.small.x86"
+}
+
+variable "em_project_id" {
+  description = "Equinix Metal project ID"
+  type        = string
+}

--- a/examples/terraform/equinix-metal/versions.tf
+++ b/examples/terraform/equinix-metal/versions.tf
@@ -1,0 +1,22 @@
+# TF setup
+
+terraform {
+  required_providers {
+    equinix = {
+      source  = "equinix/equinix"
+      version = "1.11.1"
+    }
+    talos = {
+      source  = "siderolabs/talos"
+      version = "0.1.0"
+    }
+  }
+}
+
+# Configure providers
+
+provider "equinix" {
+  auth_token = var.em_api_token
+}
+
+provider "talos" {}

--- a/examples/terraform/hcloud/terraform/versions.tf
+++ b/examples/terraform/hcloud/terraform/versions.tf
@@ -1,12 +1,13 @@
+# TF setup
 
 terraform {
   required_providers {
     hcloud = {
-      source = "hetznercloud/hcloud"
+      source  = "hetznercloud/hcloud"
       version = "1.35.2"
     }
     talos = {
-      source = "siderolabs/talos"
+      source  = "siderolabs/talos"
       version = "0.1.0"
     }
   }

--- a/examples/terraform/vultr/main.tf
+++ b/examples/terraform/vultr/main.tf
@@ -1,24 +1,3 @@
-# TF setup
-
-terraform {
-  required_providers {
-    vultr = {
-      source  = "vultr/vultr"
-      version = "2.12.0"
-    }
-    talos = {
-      source  = "siderolabs/talos"
-      version = "0.1.0"
-    }
-  }
-}
-
-# Configure providers
-
-provider "vultr" {}
-
-provider "talos" {}
-
 # Create all instances
 resource "vultr_instance" "talos_control_plane" {
   plan     = var.vultr_plan

--- a/examples/terraform/vultr/versions.tf
+++ b/examples/terraform/vultr/versions.tf
@@ -1,0 +1,20 @@
+# TF setup
+
+terraform {
+  required_providers {
+    vultr = {
+      source  = "vultr/vultr"
+      version = "2.12.0"
+    }
+    talos = {
+      source  = "siderolabs/talos"
+      version = "0.1.0"
+    }
+  }
+}
+
+# Configure providers
+
+provider "vultr" {}
+
+provider "talos" {}


### PR DESCRIPTION
This PR adds an example cluster creation in equinix metal. It also moves provider versions and provider configuration for all examples to the `versions.tf` file. This matches the guide [here](https://www.terraform-best-practices.com/code-structure) and is what we'll standardize on.

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>