### PR TITLE
feat: add aws terraform example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ The examples provided are maintained on a best effort basic and please file issu
 
 - [hcloud](./examples/terraform/hcloud)
 - [vultr](./examples/terraform/vultr)
+- [AWS](./examples/terraform/aws)

--- a/examples/terraform/aws/.terraform.lock.hcl
+++ b/examples/terraform/aws/.terraform.lock.hcl
@@ -1,0 +1,48 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.49.0"
+  constraints = ">= 3.73.0, ~> 4.0"
+  hashes = [
+    "h1:oOwWQpvQWd1uVP1axBz/TO6xzzLWoL982AY/MQfeF7I=",
+    "zh:09803937f00fdf2873eccf685eec7854408925cbf183c9b683df7c5825be463f",
+    "zh:2af1575e538fb0b669266f8d1385b17bfdaf17c521b6b6329baa1f2971fc4a4d",
+    "zh:3f71882b438cde3108fe68cfe2637839d3eed08157a9721bd97babf3912247a8",
+    "zh:577af1b38f5da8a9f29eebe5eebec9279d26e757cd03b0c8c59311f9ce8a859b",
+    "zh:60160d39094973beefb9b10cfd6aaa5b63a2e68c32445ecffcd1b101356e6f9b",
+    "zh:762656454722548baeccf35cbaa23b887976337e1ed321682df7390419fdf22d",
+    "zh:7f6d7887821659bf3bef815949077dc91ffcdb0d911644a887b6683b264a5ca6",
+    "zh:8f16a352cc903f8951fa4619c36233b3e66e27d724817b131f2035dd8896f524",
+    "zh:8f768f65e370366c8b91c00d01c9a6264fe26ea9ae1819f14bdcd12c066272bc",
+    "zh:95ad78c689a83c08ef7c3e544c3c9aca93ed528054aa77cc968ddd9efa3a1023",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a47097ab6a4ca8302da82964303ffdd2310ed65e8f8524bfe4058816cf1addb7",
+    "zh:b66d820c70cd5fd628ffe882d2b97e76b969dca4e6827ac2ba0f8d3bc5d6e9c6",
+    "zh:b80f713a4f3e1355c3dd1600e9d08b9f15ed2370054ec792ad2c01f2541abe02",
+    "zh:ce065bc3962cb71fa7652562226b9d486f3d7fcb88285c1020ebe2f550e28641",
+  ]
+}
+
+provider "registry.terraform.io/siderolabs/talos" {
+  version     = "0.1.0"
+  constraints = "0.1.0"
+  hashes = [
+    "h1:QsclpvR/YYCkpo7E5eKNEDHjEejmgq/7dxtG3ty3N7k=",
+    "zh:0fa82a384b25a58b65523e0ea4768fa1212b1f5cfc0c9379d31162454fedcc9d",
+    "zh:1d21468270d168195be50f9162d9e21488a6016e54daa0dec8e7341f97ef0664",
+    "zh:1dea41707debf4e323d25eef3924796d76ee2c6d70ff37788cbabc029b4d7ffc",
+    "zh:3e5b78ecc39a32eaa62d3f2d6394730ba1ad3e1283adbc61898caa8cc8e83e01",
+    "zh:5e8e83852c568d0385d64252d021e1df65710f1c9cf566a7ec04b8f782188e68",
+    "zh:61432003375e04f641e3d0a6c833bbf336696e9914bb2f6c80cb509a69208a51",
+    "zh:63354e6ef09c19970157912bba25888d8312aac4a16dd8c3da91da8bfc18a71d",
+    "zh:81e433b4b4a19fa83c3246717a1adb8d827c6515d20b7badb404f3ee5147017a",
+    "zh:9499a566fd1b4c0508320dc369a63b7cdd766471a96e275379959e0ae29dd9c8",
+    "zh:add534d67853b37a95ac78a19941a360a24dc616e3b87bfc3970f221516b40cd",
+    "zh:d3c0b5f092acb4f21c8bf1f9be9dd4302420b34a06d784997f8175b2ecebe61d",
+    "zh:d462db34bd75ea111ff23bfdd3af251486dbf8e21f2d07a410105bd3aeb7e055",
+    "zh:d4661849ea0ba3859f905f7811b331eff0b87e3644fa9a97a6789feaf0333464",
+    "zh:e28b1675ca3d0ccbc68df1410e641b1ca618a2d97ad6fc663d4da6a24c934663",
+    "zh:fcab9b06b397d2a25c86040f3c6ae5dc21764b0bf5adc3796f76cba8d99970b4",
+  ]
+}

--- a/examples/terraform/aws/README.md
+++ b/examples/terraform/aws/README.md
@@ -1,0 +1,19 @@
+# AWS Terraform Example
+
+This example will create a load-balanced, HA Talos cluster on AWS.
+It will use the official Sidero Labs AMI of Talos that is present and should result in a stable, maintainable cluster.
+
+## Prereqs
+
+Ensure your AWS environment is configured correctly (see https://registry.terraform.io/providers/hashicorp/aws/latest/docs#environment-variables and https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html for details).
+From this directory, issue `terraform init` to ensure the proper providers are pulled down.
+
+## Usage
+
+To create a default cluster, this should be as simple as `terraform apply`.
+This will create a cluster called `talos-aws-example` with 3 control plane nodes and a single worker in the default AWS region.
+By default, the instances will be `c5.large`, with 2 VPU and 4GB RAM each.
+If different specs or regions are required, override them through command line with the `-var` flag or by creating a varsfile and overriding with `-var-file`.
+Destroying the cluster should, again, be a simple `terraform destroy`.
+
+Getting the kubeconfig and talosconfig for this cluster can be done with `terraform output -raw kubeconfig > <desired-path-and-filename>` and `terraform output -raw talosconfig > <desired-path-and-filename>`

--- a/examples/terraform/aws/main.tf
+++ b/examples/terraform/aws/main.tf
@@ -1,0 +1,193 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+data "aws_ami" "talos" {
+  owners      = ["540036508848"] # Sidero Labs
+  most_recent = true
+  name_regex  = "^talos-v\\d+\\.\\d+\\.\\d+-${data.aws_availability_zones.available.id}-amd64$"
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 3.0"
+
+  name = var.cluster_name
+  cidr = var.vpc_cidr
+
+  azs             = data.aws_availability_zones.available.names
+  public_subnets  = [for i, v in data.aws_availability_zones.available.names: cidrsubnet(var.vpc_cidr, 2, i)]
+}
+
+module "cluster_sg" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 4.0"
+
+  name        = "${var.cluster_name}"
+  description = "Allow all intra-cluster and egress traffic"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress_with_self = [
+    {
+      rule = "all-all"
+    },
+  ]
+
+  ingress_with_cidr_blocks = [
+    {
+      from_port   = 50000
+      to_port     = 50000
+      protocol    = "tcp"
+      cidr_blocks = var.talos_api_allowed_cidr
+      description = "Talos API Access"
+    },
+  ]
+
+  egress_with_cidr_blocks = [
+    {
+      rule        = "all-all"
+      cidr_blocks = "0.0.0.0/0"
+    },
+  ]
+}
+
+module "kubernetes_api_sg" {
+  source  = "terraform-aws-modules/security-group/aws//modules/https-443"
+  version = "~> 4.0"
+
+  name                = "${var.cluster_name}-k8s-api"
+  description         = "Allow access to the Kubernetes API"
+  vpc_id              = module.vpc.vpc_id
+  ingress_cidr_blocks = [var.kubernetes_api_allowed_cidr]
+}
+
+module "elb_k8s_elb" {
+  source  = "terraform-aws-modules/elb/aws"
+  version = "~> 4.0"
+
+  name            = "${var.cluster_name}-k8s-api"
+  subnets         = module.vpc.public_subnets
+  security_groups = [
+    module.cluster_sg.security_group_id,
+    module.kubernetes_api_sg.security_group_id,
+  ]
+
+  listener = [
+    {
+      lb_port           = 443
+      lb_protocol       = "tcp"
+      instance_port     = 6443
+      instance_protocol = "tcp"
+    },
+  ]
+
+  health_check = {
+    target              = "tcp:6443"
+    interval            = 30
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 5
+  }
+
+  number_of_instances = var.num_control_planes
+  instances           = module.talos_control_plane_nodes.*.id
+}
+
+module "talos_control_plane_nodes" {
+  source  = "terraform-aws-modules/ec2-instance/aws"
+  version = "~> 4.0"
+
+  count = var.num_control_planes
+
+  name          = "${var.cluster_name}-control-plane-${count.index}"
+  ami           = data.aws_ami.talos.id
+  monitoring    = true
+  instance_type = var.instance_type
+  subnet_id     = element(module.vpc.public_subnets, count.index)
+
+  vpc_security_group_ids = [module.cluster_sg.security_group_id]
+
+  root_block_device = [
+    {
+      volume_size = 100
+    }
+  ]
+}
+
+module "talos_worker_nodes" {
+  source  = "terraform-aws-modules/ec2-instance/aws"
+  version = "~> 4.0"
+
+  count = var.num_workers
+
+  name          = "${var.cluster_name}-worker-${count.index}"
+  ami           = data.aws_ami.talos.id
+  monitoring    = true
+  instance_type = var.instance_type
+  subnet_id     = element(module.vpc.public_subnets, count.index)
+
+  vpc_security_group_ids = [module.cluster_sg.security_group_id]
+
+  root_block_device = [
+    {
+      volume_size = 100
+    }
+  ]
+}
+
+resource "talos_machine_secrets" "this" {}
+
+resource "talos_machine_configuration_controlplane" "this" {
+  cluster_name     = var.cluster_name
+  cluster_endpoint = "https://${module.elb_k8s_elb.elb_dns_name}"
+  machine_secrets  = talos_machine_secrets.this.machine_secrets
+  docs_enabled     = false
+  examples_enabled = false
+}
+
+resource "talos_machine_configuration_worker" "this" {
+  cluster_name     = var.cluster_name
+  cluster_endpoint = "https://${module.elb_k8s_elb.elb_dns_name}"
+  machine_secrets  = talos_machine_secrets.this.machine_secrets
+  docs_enabled     = false
+  examples_enabled = false
+}
+
+resource "talos_machine_configuration_apply" "controlplane" {
+  count = var.num_control_planes
+
+  talos_config          = talos_client_configuration.this.talos_config
+  machine_configuration = talos_machine_configuration_controlplane.this.machine_config
+  endpoint              = module.talos_control_plane_nodes[count.index].public_ip
+  node                  = module.talos_control_plane_nodes[count.index].private_ip
+}
+
+resource "talos_machine_configuration_apply" "worker" {
+  count = var.num_workers
+
+  talos_config          = talos_client_configuration.this.talos_config
+  machine_configuration = talos_machine_configuration_worker.this.machine_config
+  endpoint              = module.talos_worker_nodes[count.index].public_ip
+  node                  = module.talos_worker_nodes[count.index].private_ip
+}
+
+resource "talos_machine_bootstrap" "this" {
+  depends_on = [talos_machine_configuration_apply.controlplane]
+
+  talos_config = talos_client_configuration.this.talos_config
+  endpoint     = module.talos_control_plane_nodes.0.public_ip
+  node         = module.talos_control_plane_nodes.0.private_ip
+}
+
+resource "talos_client_configuration" "this" {
+  cluster_name    = var.cluster_name
+  machine_secrets = talos_machine_secrets.this.machine_secrets
+  endpoints       = module.talos_control_plane_nodes.*.public_ip
+  nodes           = flatten([module.talos_control_plane_nodes.*.private_ip, module.talos_worker_nodes.*.private_ip])
+}
+
+resource "talos_cluster_kubeconfig" "this" {
+  talos_config = talos_client_configuration.this.talos_config
+  endpoint     = module.talos_control_plane_nodes.0.public_ip
+  node         = module.talos_control_plane_nodes.0.private_ip
+}

--- a/examples/terraform/aws/outputs.tf
+++ b/examples/terraform/aws/outputs.tf
@@ -1,0 +1,9 @@
+output "talosconfig" {
+  value     = talos_client_configuration.this.talos_config
+  sensitive = true
+}
+
+output "kubeconfig" {
+  value     = talos_cluster_kubeconfig.this.kube_config
+  sensitive = true
+}

--- a/examples/terraform/aws/variables.tf
+++ b/examples/terraform/aws/variables.tf
@@ -1,0 +1,41 @@
+variable "cluster_name" {
+  description = "Name of cluster"
+  type        = string
+  default     = "talos-aws-example"
+}
+
+variable "num_control_planes" {
+  description = "Number of control plane nodes to create"
+  type        = number
+  default     = 3
+}
+
+variable "num_workers" {
+  description = "Number of worker nodes to create"
+  type        = number
+  default     = 1
+}
+
+variable "instance_type" {
+  description = "Instance type to use for the control plane nodes"
+  type        = string
+  default     = "c5.large"
+}
+
+variable "vpc_cidr" {
+  description = "The IPv4 CIDR block for the VPC."
+  type        = string
+  default     = "172.16.0.0/16"
+}
+
+variable "talos_api_allowed_cidr" {
+  description = "The CIDR from which to allow to access the Talos API"
+  type        = string
+  default     = "0.0.0.0/0"
+}
+
+variable "kubernetes_api_allowed_cidr" {
+  description = "The CIDR from which to allow to access the Kubernetes API"
+  type        = string
+  default     = "0.0.0.0/0"
+}

--- a/examples/terraform/aws/versions.tf
+++ b/examples/terraform/aws/versions.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_version = "~> 1.3"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+    talos = {
+      source  = "siderolabs/talos"
+      version = "0.1.0"
+    }
+  }
+}
+
+provider "aws" {
+  default_tags {
+    tags = {
+      Project     = "Talos Kubernetes Cluster"
+      Provisioner = "Terraform"
+      Environment = "Testing"
+    }
+  }
+}


### PR DESCRIPTION
Adds the Terraform example for a Talos cluster on AWS.

Signed-off-by: Tim Jones <tim.jones@siderolabs.com>