### PR TITLE
feat: add basic example

### DIFF
--- a/examples/terraform/basic/.terraform.lock.hcl
+++ b/examples/terraform/basic/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/siderolabs/talos" {
+  version     = "0.1.0"
+  constraints = "0.1.0"
+  hashes = [
+    "h1:QsclpvR/YYCkpo7E5eKNEDHjEejmgq/7dxtG3ty3N7k=",
+    "zh:0fa82a384b25a58b65523e0ea4768fa1212b1f5cfc0c9379d31162454fedcc9d",
+    "zh:1d21468270d168195be50f9162d9e21488a6016e54daa0dec8e7341f97ef0664",
+    "zh:1dea41707debf4e323d25eef3924796d76ee2c6d70ff37788cbabc029b4d7ffc",
+    "zh:3e5b78ecc39a32eaa62d3f2d6394730ba1ad3e1283adbc61898caa8cc8e83e01",
+    "zh:5e8e83852c568d0385d64252d021e1df65710f1c9cf566a7ec04b8f782188e68",
+    "zh:61432003375e04f641e3d0a6c833bbf336696e9914bb2f6c80cb509a69208a51",
+    "zh:63354e6ef09c19970157912bba25888d8312aac4a16dd8c3da91da8bfc18a71d",
+    "zh:81e433b4b4a19fa83c3246717a1adb8d827c6515d20b7badb404f3ee5147017a",
+    "zh:9499a566fd1b4c0508320dc369a63b7cdd766471a96e275379959e0ae29dd9c8",
+    "zh:add534d67853b37a95ac78a19941a360a24dc616e3b87bfc3970f221516b40cd",
+    "zh:d3c0b5f092acb4f21c8bf1f9be9dd4302420b34a06d784997f8175b2ecebe61d",
+    "zh:d462db34bd75ea111ff23bfdd3af251486dbf8e21f2d07a410105bd3aeb7e055",
+    "zh:d4661849ea0ba3859f905f7811b331eff0b87e3644fa9a97a6789feaf0333464",
+    "zh:e28b1675ca3d0ccbc68df1410e641b1ca618a2d97ad6fc663d4da6a24c934663",
+    "zh:fcab9b06b397d2a25c86040f3c6ae5dc21764b0bf5adc3796f76cba8d99970b4",
+  ]
+}

--- a/examples/terraform/basic/README.md
+++ b/examples/terraform/basic/README.md
@@ -1,0 +1,20 @@
+# Basic Terraform Example
+
+This example will create a basic Talos cluster using local machines.
+
+## Prereqs
+
+This guide assumes that you have pre-existing machines that have been booted with a Talos image or ISO without machine configuration, such that these machines are sitting in "maintenance mode" waiting to be provisioned.
+From this directory, issue `terraform init` to ensure the proper providers are pulled down.
+
+## Usage
+
+To create a default cluster, this should be as simple as `terraform apply`.
+You will need to specify the `cluster_name` and `cluster_endpoint` variables during application.
+The `cluster_endpoint` variable should have the form `https://<control-plane-ip-or-vip-or-dns-name>:6443`.
+This will create a cluster based on the `node_data` variable, containing the IPs of each Talos node, as well as the install disk and hostname (optional).
+
+If different configurations are required, override them through command line with the `-var` flag or by creating a varsfile and overriding with `-var-file`.
+Destroying the cluster should, again, be a simple `terraform destroy`.
+
+Getting the kubeconfig and talosconfig for this cluster can be done with `terraform output -raw kubeconfig > <desired-path-and-filename>` and `terraform output -raw talosconfig > <desired-path-and-filename>`.

--- a/examples/terraform/basic/files/patch.json
+++ b/examples/terraform/basic/files/patch.json
@@ -1,0 +1,7 @@
+[
+    {
+        "op": "add",
+        "path": "/cluster/allowSchedulingOnControlPlanes",
+        "value": true
+    }
+]

--- a/examples/terraform/basic/main.tf
+++ b/examples/terraform/basic/main.tf
@@ -1,0 +1,60 @@
+resource "talos_machine_secrets" "machine_secrets" {}
+
+resource "talos_machine_configuration_controlplane" "machineconfig_cp" {
+  cluster_name     = var.cluster_name
+  cluster_endpoint = var.cluster_endpoint
+  machine_secrets  = talos_machine_secrets.machine_secrets.machine_secrets
+}
+
+resource "talos_machine_configuration_worker" "machineconfig_worker" {
+  cluster_name     = var.cluster_name
+  cluster_endpoint = var.cluster_endpoint
+  machine_secrets  = talos_machine_secrets.machine_secrets.machine_secrets
+}
+
+resource "talos_client_configuration" "talosconfig" {
+  cluster_name    = var.cluster_name
+  machine_secrets = talos_machine_secrets.machine_secrets.machine_secrets
+  endpoints       = [for k, v in var.node_data.controlplanes : k]
+}
+
+resource "talos_machine_configuration_apply" "cp_config_apply" {
+  talos_config          = talos_client_configuration.talosconfig.talos_config
+  machine_configuration = talos_machine_configuration_controlplane.machineconfig_cp.machine_config
+  for_each              = var.node_data.controlplanes
+  endpoint              = each.key
+  node                  = each.key
+  config_patches = [
+    templatefile("${path.module}/templates/patch.yaml.tmpl", {
+      hostname     = each.value.hostname == null ? format("%s-cp-%s", var.cluster_name, index(keys(var.node_data.controlplanes), each.key)) : each.value.hostname
+      install_disk = each.value.install_disk
+    }),
+    file("${path.module}/files/patch.json"),
+  ]
+}
+
+resource "talos_machine_configuration_apply" "worker_config_apply" {
+  talos_config          = talos_client_configuration.talosconfig.talos_config
+  machine_configuration = talos_machine_configuration_worker.machineconfig_worker.machine_config
+  for_each              = var.node_data.workers
+  endpoint              = each.key
+  node                  = each.key
+  config_patches = [
+    templatefile("${path.module}/templates/patch.yaml.tmpl", {
+      hostname     = each.value.hostname == null ? format("%s-worker-%s", var.cluster_name, index(keys(var.node_data.workers), each.key)) : each.value.hostname
+      install_disk = each.value.install_disk
+    })
+  ]
+}
+
+resource "talos_machine_bootstrap" "bootstrap" {
+  talos_config = talos_client_configuration.talosconfig.talos_config
+  endpoint     = [for k, v in var.node_data.controlplanes : k][0]
+  node         = [for k, v in var.node_data.controlplanes : k][0]
+}
+
+resource "talos_cluster_kubeconfig" "kubeconfig" {
+  talos_config = talos_client_configuration.talosconfig.talos_config
+  endpoint     = [for k, v in var.node_data.controlplanes : k][0]
+  node         = [for k, v in var.node_data.controlplanes : k][0]
+}

--- a/examples/terraform/basic/outputs.tf
+++ b/examples/terraform/basic/outputs.tf
@@ -1,0 +1,19 @@
+output "machineconfig_controlplane" {
+  value     = talos_machine_configuration_controlplane.machineconfig_cp.machine_config
+  sensitive = true
+}
+
+output "machineconfig_worker" {
+  value     = talos_machine_configuration_worker.machineconfig_worker.machine_config
+  sensitive = true
+}
+
+output "talosconfig" {
+  value     = talos_client_configuration.talosconfig.talos_config
+  sensitive = true
+}
+
+output "kubeconfig" {
+  value     = talos_cluster_kubeconfig.kubeconfig.kube_config
+  sensitive = true
+}

--- a/examples/terraform/basic/templates/patch.yaml.tmpl
+++ b/examples/terraform/basic/templates/patch.yaml.tmpl
@@ -1,0 +1,5 @@
+machine:
+  install:
+    disk: ${install_disk}
+  network:
+    hostname: ${hostname}

--- a/examples/terraform/basic/variables.tf
+++ b/examples/terraform/basic/variables.tf
@@ -1,0 +1,46 @@
+variable "cluster_name" {
+  description = "A name to provide for the Talos cluster"
+  type        = string
+}
+
+variable "cluster_endpoint" {
+  description = "The endpoint for the Talos cluster"
+  type        = string
+}
+
+variable "node_data" {
+  description = "A map of node data"
+  type = object({
+    controlplanes = map(object({
+      install_disk = string
+      hostname     = optional(string)
+    }))
+    workers = map(object({
+      install_disk = string
+      hostname     = optional(string)
+    }))
+  })
+  default = {
+    controlplanes = {
+      "10.5.0.2" = {
+        install_disk = "/dev/sda"
+      },
+      "10.5.0.3" = {
+        install_disk = "/dev/sda"
+      },
+      "10.5.0.4" = {
+        install_disk = "/dev/sda"
+      }
+    }
+    workers = {
+      "10.5.0.5" = {
+        install_disk = "/dev/nvme0n1"
+        hostname     = "worker-1"
+      },
+      "10.5.0.6" = {
+        install_disk = "/dev/nvme0n1"
+        hostname     = "worker-2"
+      }
+    }
+  }
+}

--- a/examples/terraform/basic/versions.tf
+++ b/examples/terraform/basic/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    talos = {
+      source  = "siderolabs/talos"
+      version = "0.1.0"
+    }
+  }
+}
+
+provider "talos" {}


### PR DESCRIPTION
This PR moves the basic example out of the talos tf provider code into the contrib directory, as well as fixes small bugs that were causing the terraform apply to fail.

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>