### PR TITLE
fix: machine_configuration_apply of worker ref

### DIFF
--- a/examples/terraform/basic/main.tf
+++ b/examples/terraform/basic/main.tf
@@ -36,7 +36,7 @@ resource "talos_machine_configuration_apply" "controlplane" {
 
 resource "talos_machine_configuration_apply" "worker" {
   client_configuration        = talos_machine_secrets.this.client_configuration
-  machine_configuration_input = data.talos_machine_configuration.controlplane.machine_configuration
+  machine_configuration_input = data.talos_machine_configuration.worker.machine_configuration
   for_each                    = var.node_data.workers
   node                        = each.key
   config_patches = [


### PR DESCRIPTION
reference correct machine config of workers in terraform basic example