### PR TITLE
Terraform, Basic Example: Add Kubeconfig dependency for bootstrap

### DIFF
--- a/examples/terraform/basic/main.tf
+++ b/examples/terraform/basic/main.tf
@@ -55,6 +55,7 @@ resource "talos_machine_bootstrap" "this" {
 }
 
 data "talos_cluster_kubeconfig" "this" {
+  depends_on           = [talos_machine_bootstrap.this]
   client_configuration = talos_machine_secrets.this.client_configuration
   node                 = [for k, v in var.node_data.controlplanes : k][0]
   wait                 = true


### PR DESCRIPTION
The basic example would get stuck on:
```shell
data.talos_cluster_kubeconfig.this: Still reading...
```
until it timed out, then error with:
```shell
Error: failed to retrieve kubeconfig
with data.talos_cluster_kubeconfig.this,
on main.tf line 57, in data "talos_cluster_kubeconfig" "this":
57: data "talos_cluster_kubeconfig" "this" {

rpc error: code = Unimplemented desc = method Kubeconfig not implemented
```

I resolved this by adding a `depends_on = [talos_machine_bootstrap.this]`  to the `talos_cluster_kubeconfig`.