### PR TITLE
Add control_plane.tags to instance tags

### DIFF
--- a/examples/terraform/aws/main.tf
+++ b/examples/terraform/aws/main.tf
@@ -267,7 +267,7 @@ module "talos_control_plane_nodes" {
   iam_role_policies = var.ccm ? {
     "${var.cluster_name}-control-plane-ccm-policy" : aws_iam_policy.control_plane_ccm_policy[0].arn,
   } : {}
-  tags = merge(var.extra_tags, local.cluster_required_tags)
+  tags = merge(var.extra_tags, var.control_plane.tags, local.cluster_required_tags)
 
   vpc_security_group_ids = [module.cluster_sg.security_group_id]
 


### PR DESCRIPTION
The variable control_plane.tags is defined but never used, adding the variable to the merged object for control plane instance tags