### PR TITLE
omni: expose ceph dashboard

### DIFF
--- a/examples/omni/apps/rook-ceph/cluster/values.yaml
+++ b/examples/omni/apps/rook-ceph/cluster/values.yaml
@@ -1,0 +1,12 @@
+rook-ceph-cluster:
+  cephClusterSpec:
+    dashboard:
+      enabled: true
+      port: 8443
+      ssl: false
+
+    annotations:
+      dashboard:
+        # Enable Omni Workload Proxying for this service
+        omni-kube-service-exposer.sidero.dev/port: "8443"
+        omni-kube-service-exposer.sidero.dev/label: Ceph Dashboard


### PR DESCRIPTION
I thought it might be useful to also expose the Ceph Dashboard. Can see the chart values apply properly on this version of rook-ceph:

```sh
apps/rook-ceph/cluster on  main [?] is 📦 v1.13.2 via ⎈ v3.14.4
❯ helm dependency build
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "cilium" chart repository
...Successfully got an update from the "rook-release" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 1 charts
Downloading rook-ceph-cluster from repo https://charts.rook.io/release
Deleting outdated charts

apps/rook-ceph/cluster on  main [?] is 📦 v1.13.2 via ⎈ v3.14.4
❯ helm template . | rg -i sidero
      omni-kube-service-exposer.sidero.dev/label: Ceph Dashboard
      omni-kube-service-exposer.sidero.dev/port: "8443"
```
Login user name and password docs here: https://rook.io/docs/rook/latest-release/Storage-Configuration/Monitoring/ceph-dashboard/?h=dashboard#login-credentials

Worth mentioning that in the readme?