### PR TITLE
grafana: remove `allow_embedding: true`

### DIFF
--- a/examples/omni/apps/monitoring/kube-prometheus-stack/values.yaml
+++ b/examples/omni/apps/monitoring/kube-prometheus-stack/values.yaml
@@ -43,8 +43,6 @@ kube-prometheus-stack:
       auth.anonymous:
         enabled: true
     # Allow Omni Workload Proxying for this service
-      security:
-        allow_embedding: true
     service:
       annotations:
         omni-kube-service-exposer.sidero.dev/port: "50082"


### PR DESCRIPTION
From my testing it doesn't seem to be necessary:

https://github.com/grafana/grafana/blob/990ad860df25286da6c54a2085c16ba2cfc1015d/conf/sample.ini#L344

>set to true if you want to allow browsers to render Grafana in a <frame>, <iframe>, <embed> or <object>. default is false.