### PR TITLE
chore: update hetzner configuration

### DIFF
--- a/examples/terraform/basic/main.tf
+++ b/examples/terraform/basic/main.tf
@@ -58,5 +58,4 @@ resource "talos_cluster_kubeconfig" "this" {
   depends_on           = [talos_machine_bootstrap.this]
   client_configuration = talos_machine_secrets.this.client_configuration
   node                 = [for k, v in var.node_data.controlplanes : k][0]
-  wait                 = true
 }

--- a/examples/terraform/hcloud/packer/hcloud_talosimage.pkr.hcl
+++ b/examples/terraform/hcloud/packer/hcloud_talosimage.pkr.hcl
@@ -11,7 +11,7 @@ packer {
 
 variable "talos_version" {
   type    = string
-  default = "v1.3.0"
+  default = "v1.6.0"
 }
 
 locals {
@@ -20,9 +20,9 @@ locals {
 
 source "hcloud" "talos" {
   rescue       = "linux64"
-  image        = "debian-11"
+  image        = "debian-12"
   location     = "fsn1"
-  server_type  = "cx11"
+  server_type  = "cx22"
   ssh_username = "root"
 
   snapshot_name = "talos system disk ${var.talos_version}"

--- a/examples/terraform/hcloud/terraform/.terraform.lock.hcl
+++ b/examples/terraform/hcloud/terraform/.terraform.lock.hcl
@@ -2,24 +2,24 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hetznercloud/hcloud" {
-  version     = "1.35.2"
-  constraints = "1.35.2"
+  version     = "1.48.1"
+  constraints = "1.48.1"
   hashes = [
-    "h1:a/DH+2jHvgikSDajup5feRZRUwNw8OT9NBPKezjgM5g=",
-    "zh:1a7cb8f9cbd51b62bdbb4f36cdb070dd99059d86115c4777193e0f8536798d4d",
-    "zh:29c104aae7f7a4e1a4aea32febc9caa2d7d86589cd9d01d5b93dbe2cb0a73220",
-    "zh:29f082195d8f4e4cfb4050fae2ed62ed5616659c6dfaa7b5f1eb42d94d130864",
-    "zh:3cfe3876763659e27696adcb945e6da2dc2ec014ff8a2e8f0f3e610e3bfd9b73",
-    "zh:3d967f4b1aef78ffce389dd32cdea4b558ef826cec96ceb4bdafde4bb4a9b655",
-    "zh:3e160f581f7912c2053f86d6d8a3e3470fcf1fe8228b59ac216a7e40a1dd444c",
-    "zh:5138022c8b4c8a572e8097749241d929a96d3522e67ce25f86bb9fd51c4b343c",
-    "zh:5783febc4d8ac4b7fdb49607cab92ad13509d87ad4ca1999067ac3d20e815d12",
-    "zh:7f8ce9268d48beb5fa0103a8510d4fe644aaac6cd328fc4441dd37e8bdbfadab",
-    "zh:8ab6aea82657fd6f97d79b41e6cd129a33a47ce727a7d0b52205590fa3785ce1",
-    "zh:9e4bebe3bbee7875dc2e3ceca3cf0fec3254a8b481c7b96ba9a5d65647ea9092",
-    "zh:af2a912db9a6fce844ac8c0e695a5d92a5625f2df126129940051a6b1021443d",
-    "zh:bfe86d80e55f44a99dbbdca9d1caf0c837fe21d91e78674ee36263b7de71fd38",
-    "zh:d9538a361bd8979c4a87273a82fc5dec7110f3aa7ec69fffb8c70fe8937bc1f4",
+    "h1:AuI3Dw3AYY/fMrZ4EObI8XEaWzqsgiUrIRne3Nss/3Y=",
+    "zh:086cce10cb005f25f85183c59e639d6675e91e919934c80f660ca1cc4b9bc09b",
+    "zh:111d185707168b90c7ed3d245b522b2bd508f0bd4275496a1acdc9c0adaa85f2",
+    "zh:1acba3f30150282d283c46cd7ce25e9afb8b027fd2f594d41de9131d25a42b27",
+    "zh:1f8858aa81f93d52550502a11c7ea4e9370316ab098f6b75a09ffe75da6129ee",
+    "zh:20e01e6e6f99f57b3c1ef2a9de5d617c0139d3f3934eeb5e6c5976ae8b831a48",
+    "zh:2a8489a586a7bdadc42bbc9e3cb7b9deaefdf8020e3f2caba2678877d5d64d52",
+    "zh:31d8017529b0429bc9e873ec5d358ab9b75af2ba0ae24f21abcd4d09f36b7ee9",
+    "zh:407b4d7f1407e7e4a51b6f4dcdb0c7fbf81f2f1e25a7275f34054009419125a2",
+    "zh:42cf7cf867d199054713d4e6060e4b578eff16f0f537e9aaa5fd990c3eab8bc6",
+    "zh:460ac856ff952c5d41525949b93cfb7ee642f900594eff965494f11999d7496b",
+    "zh:d09e527d23f62564c82bc24e286cf2cb8cb0ed6cdc6f4c66adf2145cfa62adac",
+    "zh:d465356710444ac70dea4883252efc429b73e79fc6dc94f075662b838476680e",
+    "zh:d476c8eca307e30a20eed54c0735b062a6f3066b4ac63eebecd38ab8f40c16f4",
+    "zh:e0e9b2f6d5e28dbd01fa1ec3147aa88062d6223c5146532a3dcd1d3bb827e1e9",
   ]
 }
 
@@ -27,9 +27,9 @@ provider "registry.terraform.io/siderolabs/talos" {
   version     = "0.6.0-beta.0"
   constraints = "0.6.0-beta.0"
   hashes = [
-    "h1:DQK39Aog1m1YDnyMF0o2ZkM5dbHatidHli/YFLsgJiA=",
-    "zh:0a511e0c85ba9875f91e11c0761041bf9a45c1f0e380304c1686dbbc95091efa",
-    "zh:0ab4aec2d38686f72b6425e0f457b1f34656f9b3941939c8946c6ae0e1cadf98",
+    "h1:IX9Y61mR4eFotOytteoWIg+KE0J0GSw+CVH8JWjSPYc=",
+    "h1:k9EvpEqKd9Twa2JGa7Xyzx0PsnbtaqfmHLitrbi1BuM=",
+    "zh:0e1b2168f8fe1fe922a017ce11b2686666d249e76c46878fee04409689fe86c1",
     "zh:0fa82a384b25a58b65523e0ea4768fa1212b1f5cfc0c9379d31162454fedcc9d",
     "zh:266c42476d4d87eafef4e00608beaa091818da83449aa686e12e5198ea8461d1",
     "zh:2b978574a217949210f4159092014a45f1a19bbf65887565627f7677a40bacfd",

--- a/examples/terraform/hcloud/terraform/README.md
+++ b/examples/terraform/hcloud/terraform/README.md
@@ -3,14 +3,14 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_hcloud"></a> [hcloud](#requirement\_hcloud) | 1.35.2 |
+| <a name="requirement_hcloud"></a> [hcloud](#requirement\_hcloud) | 1.48.1 |
 | <a name="requirement_talos"></a> [talos](#requirement\_talos) | 0.6.0-beta.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_hcloud"></a> [hcloud](#provider\_hcloud) | 1.35.2 |
+| <a name="provider_hcloud"></a> [hcloud](#provider\_hcloud) | 1.48.1 |
 | <a name="provider_talos"></a> [talos](#provider\_talos) | 0.6.0-beta.0 |
 
 ## Modules
@@ -21,17 +21,17 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [hcloud_load_balancer.controlplane_load_balancer](https://registry.terraform.io/providers/hetznercloud/hcloud/1.35.2/docs/resources/load_balancer) | resource |
-| [hcloud_load_balancer_network.srvnetwork](https://registry.terraform.io/providers/hetznercloud/hcloud/1.35.2/docs/resources/load_balancer_network) | resource |
-| [hcloud_load_balancer_service.controlplane_load_balancer_service_kubectl](https://registry.terraform.io/providers/hetznercloud/hcloud/1.35.2/docs/resources/load_balancer_service) | resource |
-| [hcloud_load_balancer_service.controlplane_load_balancer_service_mayastor](https://registry.terraform.io/providers/hetznercloud/hcloud/1.35.2/docs/resources/load_balancer_service) | resource |
-| [hcloud_load_balancer_service.controlplane_load_balancer_service_talosctl](https://registry.terraform.io/providers/hetznercloud/hcloud/1.35.2/docs/resources/load_balancer_service) | resource |
-| [hcloud_load_balancer_target.load_balancer_target](https://registry.terraform.io/providers/hetznercloud/hcloud/1.35.2/docs/resources/load_balancer_target) | resource |
-| [hcloud_network.network](https://registry.terraform.io/providers/hetznercloud/hcloud/1.35.2/docs/resources/network) | resource |
-| [hcloud_network_subnet.subnet](https://registry.terraform.io/providers/hetznercloud/hcloud/1.35.2/docs/resources/network_subnet) | resource |
-| [hcloud_server.controlplane_server](https://registry.terraform.io/providers/hetznercloud/hcloud/1.35.2/docs/resources/server) | resource |
-| [hcloud_server.worker_server](https://registry.terraform.io/providers/hetznercloud/hcloud/1.35.2/docs/resources/server) | resource |
-| [hcloud_volume.volumes](https://registry.terraform.io/providers/hetznercloud/hcloud/1.35.2/docs/resources/volume) | resource |
+| [hcloud_load_balancer.controlplane_load_balancer](https://registry.terraform.io/providers/hetznercloud/hcloud/1.48.1/docs/resources/load_balancer) | resource |
+| [hcloud_load_balancer_network.srvnetwork](https://registry.terraform.io/providers/hetznercloud/hcloud/1.48.1/docs/resources/load_balancer_network) | resource |
+| [hcloud_load_balancer_service.controlplane_load_balancer_service_kubectl](https://registry.terraform.io/providers/hetznercloud/hcloud/1.48.1/docs/resources/load_balancer_service) | resource |
+| [hcloud_load_balancer_service.controlplane_load_balancer_service_mayastor](https://registry.terraform.io/providers/hetznercloud/hcloud/1.48.1/docs/resources/load_balancer_service) | resource |
+| [hcloud_load_balancer_service.controlplane_load_balancer_service_talosctl](https://registry.terraform.io/providers/hetznercloud/hcloud/1.48.1/docs/resources/load_balancer_service) | resource |
+| [hcloud_load_balancer_target.load_balancer_target](https://registry.terraform.io/providers/hetznercloud/hcloud/1.48.1/docs/resources/load_balancer_target) | resource |
+| [hcloud_network.network](https://registry.terraform.io/providers/hetznercloud/hcloud/1.48.1/docs/resources/network) | resource |
+| [hcloud_network_subnet.subnet](https://registry.terraform.io/providers/hetznercloud/hcloud/1.48.1/docs/resources/network_subnet) | resource |
+| [hcloud_server.controlplane_server](https://registry.terraform.io/providers/hetznercloud/hcloud/1.48.1/docs/resources/server) | resource |
+| [hcloud_server.worker_server](https://registry.terraform.io/providers/hetznercloud/hcloud/1.48.1/docs/resources/server) | resource |
+| [hcloud_volume.volumes](https://registry.terraform.io/providers/hetznercloud/hcloud/1.48.1/docs/resources/volume) | resource |
 | [talos_cluster_kubeconfig.this](https://registry.terraform.io/providers/siderolabs/talos/0.6.0-beta.0/docs/resources/cluster_kubeconfig) | resource |
 | [talos_machine_bootstrap.bootstrap](https://registry.terraform.io/providers/siderolabs/talos/0.6.0-beta.0/docs/resources/machine_bootstrap) | resource |
 | [talos_machine_secrets.this](https://registry.terraform.io/providers/siderolabs/talos/0.6.0-beta.0/docs/resources/machine_secrets) | resource |
@@ -45,14 +45,16 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | A name to provide for the Talos cluster | `string` | `"talos-hloud-cluster"` | no |
 | <a name="input_controlplane_ip"></a> [controlplane\_ip](#input\_controlplane\_ip) | n/a | `string` | `"10.0.0.3"` | no |
-| <a name="input_controlplane_type"></a> [controlplane\_type](#input\_controlplane\_type) | Control plane | `string` | `"cpx31"` | no |
+| <a name="input_controlplane_type"></a> [controlplane\_type](#input\_controlplane\_type) | Control plane | `string` | `"cx32"` | no |
 | <a name="input_image_id"></a> [image\_id](#input\_image\_id) | Talos specific variables | `string` | n/a | yes |
+| <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Kubernetes version to use for the cluster, if not set the k8s version shipped with the talos sdk version will be used | `string` | `null` | no |
 | <a name="input_load_balancer_type"></a> [load\_balancer\_type](#input\_load\_balancer\_type) | n/a | `string` | `"lb11"` | no |
 | <a name="input_location"></a> [location](#input\_location) | Workers | `string` | `"fsn1"` | no |
 | <a name="input_network_zone"></a> [network\_zone](#input\_network\_zone) | Load balancer | `string` | `"eu-central"` | no |
 | <a name="input_private_network_ip_range"></a> [private\_network\_ip\_range](#input\_private\_network\_ip\_range) | n/a | `string` | `"10.0.0.0/16"` | no |
 | <a name="input_private_network_name"></a> [private\_network\_name](#input\_private\_network\_name) | Networking | `string` | `"talos-network"` | no |
 | <a name="input_private_network_subnet_range"></a> [private\_network\_subnet\_range](#input\_private\_network\_subnet\_range) | n/a | `string` | `"10.0.0.0/24"` | no |
+| <a name="input_talos_version_contract"></a> [talos\_version\_contract](#input\_talos\_version\_contract) | Talos API version to use for the cluster, if not set the the version shipped with the talos sdk version will be used | `string` | `"v1.6"` | no |
 | <a name="input_worker_extra_volume_size"></a> [worker\_extra\_volume\_size](#input\_worker\_extra\_volume\_size) | Size of SSD volume to attach to workers | `number` | `10` | no |
 | <a name="input_workers"></a> [workers](#input\_workers) | Worker definition | `any` | n/a | yes |
 

--- a/examples/terraform/hcloud/terraform/three_workers.tfvars
+++ b/examples/terraform/hcloud/terraform/three_workers.tfvars
@@ -1,20 +1,20 @@
 workers = {
   1 = {
-    server_type = "cpx31",
+    server_type = "cx32",
     name        = "talos-worker-1",
     location    = "fsn1",
     labels      = { "type" : "talos-worker" },
     taints      = [],
   },
   2 = {
-    server_type = "cpx31",
+    server_type = "cx32",
     name        = "talos-worker-2",
     location    = "fsn1",
     labels      = { "type" : "talos-worker" },
     taints      = [],
   },
   3 = {
-    server_type = "cpx31",
+    server_type = "cx32",
     name        = "talos-worker-3",
     location    = "fsn1",
     labels      = { "type" : "talos-worker" },

--- a/examples/terraform/hcloud/terraform/variables.tf
+++ b/examples/terraform/hcloud/terraform/variables.tf
@@ -9,9 +9,21 @@ variable "cluster_name" {
   default     = "talos-hloud-cluster"
 }
 
+variable "talos_version_contract" {
+  description = "Talos API version to use for the cluster, if not set the the version shipped with the talos sdk version will be used"
+  type        = string
+  default     = "v1.6"
+}
+
+variable "kubernetes_version" {
+  description = "Kubernetes version to use for the cluster, if not set the k8s version shipped with the talos sdk version will be used"
+  type        = string
+  default     = null
+}
+
 # Control plane
 variable "controlplane_type" {
-  default = "cpx31"
+  default = "cx32"
 }
 
 variable "controlplane_ip" {
@@ -51,7 +63,7 @@ variable "workers" {
 }
 
 variable "worker_extra_volume_size" {
-  description = " Size of SSD volume to attach to workers"
+  description = "Size of SSD volume to attach to workers"
   type        = number
   default     = 10
 }

--- a/examples/terraform/hcloud/terraform/versions.tf
+++ b/examples/terraform/hcloud/terraform/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     hcloud = {
       source  = "hetznercloud/hcloud"
-      version = "1.35.2"
+      version = "1.48.1"
     }
     talos = {
       source  = "siderolabs/talos"


### PR DESCRIPTION
Update the example Packer and Terraform configuration.
- Remove "wait" from talos_cluster_kubeconfig
- Update Talos version from v1.3.0 to v1.6.0
- Update Hetzner server types