### PR TITLE
fix: revert allow EC2 metadata access to tags

### DIFF
--- a/examples/terraform/aws/main.tf
+++ b/examples/terraform/aws/main.tf
@@ -270,10 +270,6 @@ module "talos_control_plane_nodes" {
   } : {}
   tags = merge(var.extra_tags, var.control_plane.tags, local.cluster_required_tags)
 
-  metadata_options = {
-    "instance_metadata_tags" : "enabled"
-  }
-
   vpc_security_group_ids = [module.cluster_sg.security_group_id]
 
   root_block_device = [
@@ -300,10 +296,6 @@ module "talos_worker_group" {
     "${var.cluster_name}-worker-ccm-policy" : aws_iam_policy.worker_ccm_policy[0].arn,
   } : {}
   tags = merge(each.value.tags, var.extra_tags, local.cluster_required_tags)
-
-  metadata_options = {
-    "instance_metadata_tags" : "enabled"
-  }
 
   vpc_security_group_ids = [module.cluster_sg.security_group_id]
 


### PR DESCRIPTION
This reverts commit 90b90aef06cb5711c40f7ab661bccd048f2a1777.

It looks like this puts restriction on tag names and breaks the e2e-aws.