### PR TITLE
fix: aws elb name length

### DIFF
--- a/examples/terraform/advanced/README.md
+++ b/examples/terraform/advanced/README.md
@@ -24,7 +24,7 @@ Getting the kubeconfig and talosconfig for this cluster can be done with `terraf
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_libvirt"></a> [libvirt](#requirement\_libvirt) | 0.7.1 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.5.1 |
 | <a name="requirement_talos"></a> [talos](#requirement\_talos) | 0.11.0-beta.1 |
@@ -33,7 +33,7 @@ Getting the kubeconfig and talosconfig for this cluster can be done with `terraf
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_libvirt"></a> [libvirt](#provider\_libvirt) | 0.7.1 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 | <a name="provider_talos"></a> [talos](#provider\_talos) | 0.11.0-beta.1 |
@@ -42,14 +42,14 @@ Getting the kubeconfig and talosconfig for this cluster can be done with `terraf
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_bootstrap_token"></a> [bootstrap\_token](#module\_bootstrap\_token) | ./modules/bootstrap_token | n/a |
 | <a name="module_trustdinfo_token"></a> [trustdinfo\_token](#module\_trustdinfo\_token) | ./modules/bootstrap_token | n/a |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [libvirt_domain.cp](https://registry.terraform.io/providers/dmacvicar/libvirt/0.7.1/docs/resources/domain) | resource |
 | [libvirt_volume.cp](https://registry.terraform.io/providers/dmacvicar/libvirt/0.7.1/docs/resources/volume) | resource |
 | [random_id.cluster_id](https://registry.terraform.io/providers/hashicorp/random/3.5.1/docs/resources/id) | resource |
@@ -78,14 +78,14 @@ Getting the kubeconfig and talosconfig for this cluster can be done with `terraf
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | A name to provide for the Talos cluster | `string` | n/a | yes |
 | <a name="input_iso_path"></a> [iso\_path](#input\_iso\_path) | Path to the Talos ISO | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_kubeconfig"></a> [kubeconfig](#output\_kubeconfig) | n/a |
 | <a name="output_talosconfig"></a> [talosconfig](#output\_talosconfig) | n/a |
 <!-- END_TF_DOCS -->

--- a/examples/terraform/advanced/modules/bootstrap_token/README.md
+++ b/examples/terraform/advanced/modules/bootstrap_token/README.md
@@ -2,13 +2,13 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.5.1 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Modules
@@ -18,7 +18,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [random_string.token_prefix](https://registry.terraform.io/providers/hashicorp/random/3.5.1/docs/resources/string) | resource |
 | [random_string.token_suffix](https://registry.terraform.io/providers/hashicorp/random/3.5.1/docs/resources/string) | resource |
 
@@ -29,6 +29,6 @@ No inputs.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_bootstrap_token"></a> [bootstrap\_token](#output\_bootstrap\_token) | n/a |
 <!-- END_TF_DOCS -->

--- a/examples/terraform/aws/README.md
+++ b/examples/terraform/aws/README.md
@@ -2,21 +2,21 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.38.0 |
 | <a name="requirement_talos"></a> [talos](#requirement\_talos) | 0.11.0-beta.1 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 6.38.0 |
 | <a name="provider_talos"></a> [talos](#provider\_talos) | 0.11.0-beta.1 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_cluster_sg"></a> [cluster\_sg](#module\_cluster\_sg) | terraform-aws-modules/security-group/aws | ~> 5.0 |
 | <a name="module_elb_k8s_elb"></a> [elb\_k8s\_elb](#module\_elb\_k8s\_elb) | terraform-aws-modules/elb/aws | ~> 4.0 |
 | <a name="module_kubernetes_api_sg"></a> [kubernetes\_api\_sg](#module\_kubernetes\_api\_sg) | terraform-aws-modules/security-group/aws//modules/https-443 | ~> 5.0 |
@@ -27,7 +27,7 @@
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_iam_policy.control_plane_ccm_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.worker_ccm_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [talos_cluster_kubeconfig.this](https://registry.terraform.io/providers/siderolabs/talos/0.11.0-beta.1/docs/resources/cluster_kubeconfig) | resource |
@@ -45,7 +45,7 @@
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_ccm"></a> [ccm](#input\_ccm) | Whether to deploy aws cloud controller manager | `bool` | `false` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of cluster | `string` | `"talos-aws-example"` | no |
 | <a name="input_config_patch_files"></a> [config\_patch\_files](#input\_config\_patch\_files) | Path to talos config path files that applies to all nodes | `list(string)` | `[]` | no |
@@ -61,7 +61,7 @@
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_kubeconfig"></a> [kubeconfig](#output\_kubeconfig) | The generated kubeconfig. |
 | <a name="output_talosconfig"></a> [talosconfig](#output\_talosconfig) | The generated talosconfig. |
 <!-- END_TF_DOCS -->

--- a/examples/terraform/aws/main.tf
+++ b/examples/terraform/aws/main.tf
@@ -1,9 +1,7 @@
 locals {
   # Generate a safe cluster name limited to 32 characters
-  # Keep first 16 chars as-is, use SHA256 hash of remaining chars for last 16
-  # also trim trailing dashes
-  # This is to ensure compatibility with AWS resource naming restrictions
-  cluster_name_safe = length(var.cluster_name) <= 32 ? var.cluster_name : "${trimsuffix(substr(var.cluster_name, 0, 16), "-")}${substr(sha256(substr(var.cluster_name, 16, -1)), 0, 16)}"
+  # This is necessary because AWS resource names often have length restrictions, and using a UUID ensures uniqueness while avoiding issues with special characters.
+  cluster_name_safe = substr(uuidv5("oid", var.cluster_name), 0, 32)
 
   common_machine_config_patch = {
     machine = {
@@ -119,7 +117,7 @@ module "elb_k8s_elb" {
   source  = "terraform-aws-modules/elb/aws"
   version = "~> 4.0"
 
-  name    = trimsuffix(substr("${local.cluster_name_safe}-k8s-api", 0, 32), "-")
+  name    = local.cluster_name_safe
   subnets = module.vpc.public_subnets
   tags    = merge(var.extra_tags, local.cluster_required_tags)
   security_groups = [

--- a/examples/terraform/aws/versions.tf
+++ b/examples/terraform/aws/versions.tf
@@ -17,6 +17,7 @@ provider "aws" {
       Project     = "Talos Kubernetes Cluster"
       Provisioner = "Terraform"
       Environment = "Testing"
+      ClusterName = var.cluster_name
     }
   }
 }

--- a/examples/terraform/azure/README.md
+++ b/examples/terraform/azure/README.md
@@ -41,7 +41,7 @@ Getting the kubeconfig and talosconfig for this cluster can be done with `terraf
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.0 |
 | <a name="requirement_talos"></a> [talos](#requirement\_talos) | 0.11.0-beta.1 |
@@ -49,14 +49,14 @@ Getting the kubeconfig and talosconfig for this cluster can be done with `terraf
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.117.1 |
 | <a name="provider_talos"></a> [talos](#provider\_talos) | 0.11.0-beta.1 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_control_plane_sg"></a> [control\_plane\_sg](#module\_control\_plane\_sg) | Azure/network-security-group/azurerm | ~> 3.0 |
 | <a name="module_kubernetes_api_lb"></a> [kubernetes\_api\_lb](#module\_kubernetes\_api\_lb) | Azure/loadbalancer/azurerm | ~> 4.0 |
 | <a name="module_talos_control_plane_nodes"></a> [talos\_control\_plane\_nodes](#module\_talos\_control\_plane\_nodes) | Azure/compute/azurerm | ~> 5.0 |
@@ -66,7 +66,7 @@ Getting the kubeconfig and talosconfig for this cluster can be done with `terraf
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [azurerm_network_interface_backend_address_pool_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface_backend_address_pool_association) | resource |
 | [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [talos_cluster_kubeconfig.this](https://registry.terraform.io/providers/siderolabs/talos/0.11.0-beta.1/docs/resources/cluster_kubeconfig) | resource |
@@ -82,7 +82,7 @@ Getting the kubeconfig and talosconfig for this cluster can be done with `terraf
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_azure_location"></a> [azure\_location](#input\_azure\_location) | Azure location to use | `string` | `"West Europe"` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of cluster | `string` | `"talos-azure-example"` | no |
 | <a name="input_config_patch_files"></a> [config\_patch\_files](#input\_config\_patch\_files) | Path to talos config path files that applies to all nodes | `list(string)` | `[]` | no |
@@ -98,7 +98,7 @@ Getting the kubeconfig and talosconfig for this cluster can be done with `terraf
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_kubeconfig"></a> [kubeconfig](#output\_kubeconfig) | n/a |
 | <a name="output_talosconfig"></a> [talosconfig](#output\_talosconfig) | n/a |
 <!-- END_TF_DOCS -->

--- a/examples/terraform/basic/README.md
+++ b/examples/terraform/basic/README.md
@@ -23,13 +23,13 @@ Getting the kubeconfig and talosconfig for this cluster can be done with `terraf
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_talos"></a> [talos](#requirement\_talos) | 0.11.0-beta.1 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_talos"></a> [talos](#provider\_talos) | 0.11.0-beta.1 |
 
 ## Modules
@@ -39,7 +39,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [talos_cluster_kubeconfig.this](https://registry.terraform.io/providers/siderolabs/talos/0.11.0-beta.1/docs/resources/cluster_kubeconfig) | resource |
 | [talos_machine_bootstrap.this](https://registry.terraform.io/providers/siderolabs/talos/0.11.0-beta.1/docs/resources/machine_bootstrap) | resource |
 | [talos_machine_configuration_apply.controlplane](https://registry.terraform.io/providers/siderolabs/talos/0.11.0-beta.1/docs/resources/machine_configuration_apply) | resource |
@@ -52,7 +52,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_cluster_endpoint"></a> [cluster\_endpoint](#input\_cluster\_endpoint) | The endpoint for the Talos cluster | `string` | n/a | yes |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | A name to provide for the Talos cluster | `string` | n/a | yes |
 | <a name="input_node_data"></a> [node\_data](#input\_node\_data) | A map of node data | <pre>object({<br/>    controlplanes = map(object({<br/>      install_disk = string<br/>      hostname     = optional(string)<br/>    }))<br/>    workers = map(object({<br/>      install_disk = string<br/>      hostname     = optional(string)<br/>    }))<br/>  })</pre> | <pre>{<br/>  "controlplanes": {<br/>    "10.5.0.2": {<br/>      "install_disk": "/dev/sda"<br/>    },<br/>    "10.5.0.3": {<br/>      "install_disk": "/dev/sda"<br/>    },<br/>    "10.5.0.4": {<br/>      "install_disk": "/dev/sda"<br/>    }<br/>  },<br/>  "workers": {<br/>    "10.5.0.5": {<br/>      "hostname": "worker-1",<br/>      "install_disk": "/dev/nvme0n1"<br/>    },<br/>    "10.5.0.6": {<br/>      "hostname": "worker-2",<br/>      "install_disk": "/dev/nvme0n1"<br/>    }<br/>  }<br/>}</pre> | no |
@@ -60,7 +60,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_kubeconfig"></a> [kubeconfig](#output\_kubeconfig) | n/a |
 | <a name="output_talosconfig"></a> [talosconfig](#output\_talosconfig) | n/a |
 <!-- END_TF_DOCS -->

--- a/examples/terraform/digitalocean/README.md
+++ b/examples/terraform/digitalocean/README.md
@@ -22,14 +22,14 @@ Getting the kubeconfig and talosconfig for this cluster can be done with `terraf
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_digitalocean"></a> [digitalocean](#requirement\_digitalocean) | 2.28.0 |
 | <a name="requirement_talos"></a> [talos](#requirement\_talos) | 0.11.0-beta.1 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_digitalocean"></a> [digitalocean](#provider\_digitalocean) | 2.28.0 |
 | <a name="provider_talos"></a> [talos](#provider\_talos) | 0.11.0-beta.1 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | 4.2.1 |
@@ -41,7 +41,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [digitalocean_custom_image.talos_custom_image](https://registry.terraform.io/providers/digitalocean/digitalocean/2.28.0/docs/resources/custom_image) | resource |
 | [digitalocean_droplet.talos_control_plane](https://registry.terraform.io/providers/digitalocean/digitalocean/2.28.0/docs/resources/droplet) | resource |
 | [digitalocean_droplet.talos_workers](https://registry.terraform.io/providers/digitalocean/digitalocean/2.28.0/docs/resources/droplet) | resource |
@@ -60,7 +60,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of cluster | `string` | `"talos-do"` | no |
 | <a name="input_do_plan_control_plane"></a> [do\_plan\_control\_plane](#input\_do\_plan\_control\_plane) | DO plan to use for control plane nodes | `string` | `"s-2vcpu-4gb"` | no |
 | <a name="input_do_plan_worker"></a> [do\_plan\_worker](#input\_do\_plan\_worker) | DO plan to use for worker nodes | `string` | `"s-2vcpu-4gb"` | no |
@@ -72,7 +72,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_kubeconfig"></a> [kubeconfig](#output\_kubeconfig) | n/a |
 | <a name="output_talosconfig"></a> [talosconfig](#output\_talosconfig) | n/a |
 <!-- END_TF_DOCS -->

--- a/examples/terraform/gcp/README.md
+++ b/examples/terraform/gcp/README.md
@@ -2,7 +2,7 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | ~> 6.0 |
 | <a name="requirement_talos"></a> [talos](#requirement\_talos) | 0.11.0-beta.1 |
@@ -10,20 +10,20 @@
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_google"></a> [google](#provider\_google) | 6.50.0 |
 | <a name="provider_talos"></a> [talos](#provider\_talos) | 0.11.0-beta.1 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-google-modules/network/google | ~> 9.1 |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [google_compute_backend_service.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_backend_service) | resource |
 | [google_compute_firewall.health-check](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_firewall.talos-api](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
@@ -50,7 +50,7 @@
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of cluster | `string` | `"talos-gcp-example"` | no |
 | <a name="input_config_patch_files"></a> [config\_patch\_files](#input\_config\_patch\_files) | Path to talos config path files that applies to all nodes | `list(string)` | `[]` | no |
 | <a name="input_control_plane"></a> [control\_plane](#input\_control\_plane) | Info for control plane that will be created | <pre>object({<br/>    instance_type      = optional(string, "e2-standard-2")<br/>    image              = optional(string, null)<br/>    num_instances      = optional(number, 3)<br/>    config_patch_files = optional(list(string), [])<br/>    tags               = optional(map(string), {})<br/>  })</pre> | `{}` | no |
@@ -66,7 +66,7 @@
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_kubeconfig"></a> [kubeconfig](#output\_kubeconfig) | The generated kubeconfig. |
 | <a name="output_talosconfig"></a> [talosconfig](#output\_talosconfig) | The generated talosconfig. |
 <!-- END_TF_DOCS -->

--- a/examples/terraform/hcloud/terraform/README.md
+++ b/examples/terraform/hcloud/terraform/README.md
@@ -2,14 +2,14 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_hcloud"></a> [hcloud](#requirement\_hcloud) | 1.48.1 |
 | <a name="requirement_talos"></a> [talos](#requirement\_talos) | 0.11.0-beta.1 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_hcloud"></a> [hcloud](#provider\_hcloud) | 1.48.1 |
 | <a name="provider_talos"></a> [talos](#provider\_talos) | 0.11.0-beta.1 |
 
@@ -20,7 +20,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [hcloud_load_balancer.controlplane_load_balancer](https://registry.terraform.io/providers/hetznercloud/hcloud/1.48.1/docs/resources/load_balancer) | resource |
 | [hcloud_load_balancer_network.srvnetwork](https://registry.terraform.io/providers/hetznercloud/hcloud/1.48.1/docs/resources/load_balancer_network) | resource |
 | [hcloud_load_balancer_service.controlplane_load_balancer_service_kubectl](https://registry.terraform.io/providers/hetznercloud/hcloud/1.48.1/docs/resources/load_balancer_service) | resource |
@@ -42,7 +42,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | A name to provide for the Talos cluster | `string` | `"talos-hloud-cluster"` | no |
 | <a name="input_controlplane_ip"></a> [controlplane\_ip](#input\_controlplane\_ip) | n/a | `string` | `"10.0.0.3"` | no |
 | <a name="input_controlplane_type"></a> [controlplane\_type](#input\_controlplane\_type) | Control plane | `string` | `"cx32"` | no |
@@ -61,7 +61,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_kubeconfig"></a> [kubeconfig](#output\_kubeconfig) | n/a |
 | <a name="output_talosconfig"></a> [talosconfig](#output\_talosconfig) | n/a |
 <!-- END_TF_DOCS -->

--- a/examples/terraform/vultr/README.md
+++ b/examples/terraform/vultr/README.md
@@ -21,14 +21,14 @@ Getting the kubeconfig and talosconfig for this cluster can be done with `terraf
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_talos"></a> [talos](#requirement\_talos) | 0.11.0-beta.1 |
 | <a name="requirement_vultr"></a> [vultr](#requirement\_vultr) | 2.12.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_talos"></a> [talos](#provider\_talos) | 0.11.0-beta.1 |
 | <a name="provider_vultr"></a> [vultr](#provider\_vultr) | 2.12.0 |
 
@@ -39,7 +39,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [talos_cluster_kubeconfig.this](https://registry.terraform.io/providers/siderolabs/talos/0.11.0-beta.1/docs/resources/cluster_kubeconfig) | resource |
 | [talos_machine_bootstrap.this](https://registry.terraform.io/providers/siderolabs/talos/0.11.0-beta.1/docs/resources/machine_bootstrap) | resource |
 | [talos_machine_configuration_apply.controlplane](https://registry.terraform.io/providers/siderolabs/talos/0.11.0-beta.1/docs/resources/machine_configuration_apply) | resource |
@@ -55,7 +55,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of cluster | `string` | `"talos-vultr"` | no |
 | <a name="input_num_control_plane"></a> [num\_control\_plane](#input\_num\_control\_plane) | Number of control plane nodes to create | `number` | `3` | no |
 | <a name="input_num_workers"></a> [num\_workers](#input\_num\_workers) | Number of worker nodes to create | `number` | `1` | no |
@@ -65,7 +65,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_kubeconfig"></a> [kubeconfig](#output\_kubeconfig) | n/a |
 | <a name="output_talosconfig"></a> [talosconfig](#output\_talosconfig) | n/a |
 <!-- END_TF_DOCS -->

--- a/examples/terraform/xenorchestra/simple/README.md
+++ b/examples/terraform/xenorchestra/simple/README.md
@@ -6,7 +6,7 @@ No requirements.
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_xenorchestra"></a> [xenorchestra](#provider\_xenorchestra) | 0.37.4 |
 
 ## Modules
@@ -16,7 +16,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [xenorchestra_vm.cp](https://registry.terraform.io/providers/vatesfr/xenorchestra/latest/docs/resources/vm) | resource |
 | [xenorchestra_vm.worker](https://registry.terraform.io/providers/vatesfr/xenorchestra/latest/docs/resources/vm) | resource |
 | [xenorchestra_network.net](https://registry.terraform.io/providers/vatesfr/xenorchestra/latest/docs/data-sources/network) | data source |
@@ -26,7 +26,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the Talos cluster | `string` | `"demo-talos"` | no |
 | <a name="input_cp_cpus"></a> [cp\_cpus](#input\_cp\_cpus) | Number of CPUs for control plane | `number` | `2` | no |
 | <a name="input_cp_disk_size_gb"></a> [cp\_disk\_size\_gb](#input\_cp\_disk\_size\_gb) | Control plane disk size in GB | `number` | `20` | no |

--- a/examples/terraform/xenorchestra/with-talos-provider/README.md
+++ b/examples/terraform/xenorchestra/with-talos-provider/README.md
@@ -2,13 +2,13 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_talos"></a> [talos](#requirement\_talos) | 0.9.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_talos"></a> [talos](#provider\_talos) | 0.9.0 |
 | <a name="provider_xenorchestra"></a> [xenorchestra](#provider\_xenorchestra) | 0.37.4 |
 
@@ -19,7 +19,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [talos_cluster_kubeconfig.this](https://registry.terraform.io/providers/siderolabs/talos/0.9.0/docs/resources/cluster_kubeconfig) | resource |
 | [talos_machine_bootstrap.this](https://registry.terraform.io/providers/siderolabs/talos/0.9.0/docs/resources/machine_bootstrap) | resource |
 | [talos_machine_configuration_apply.controlplane](https://registry.terraform.io/providers/siderolabs/talos/0.9.0/docs/resources/machine_configuration_apply) | resource |
@@ -38,7 +38,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_cluster_endpoint"></a> [cluster\_endpoint](#input\_cluster\_endpoint) | The endpoint for the Talos cluster (defaults to https://<cluster\_vip>:6443) | `string` | `null` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the Talos cluster | `string` | `"demo-talos"` | no |
 | <a name="input_cluster_vip"></a> [cluster\_vip](#input\_cluster\_vip) | The virtual IP for the Talos cluster | `string` | n/a | yes |
@@ -63,7 +63,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_kubeconfig"></a> [kubeconfig](#output\_kubeconfig) | n/a |
 | <a name="output_talosconfig"></a> [talosconfig](#output\_talosconfig) | n/a |
 <!-- END_TF_DOCS -->


### PR DESCRIPTION
Use safe naming limited to 32 characters for ELB names.